### PR TITLE
feat: enable arm64 builds

### DIFF
--- a/charon-validator/entrypoint.lodestar.sh
+++ b/charon-validator/entrypoint.lodestar.sh
@@ -171,6 +171,7 @@ function run_validator_client() {
             --graffiti="${GRAFFITI}" \
             --suggestedFeeRecipient="${DEFAULT_FEE_RECIPIENT}" \
             --distributed \
+            --useProduceBlockV3="false" \
             ${VALIDATOR_EXTRA_OPTS}
     ) &
     VALIDATOR_CLIENT_PID=$!

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -11,7 +11,7 @@
   "links": {
     "homepage": "https://obol.tech/"
   },
-  "architectures": ["linux/amd64"],
+  "architectures": ["linux/amd64", "linux/arm64"],
   "backup": [
     {
       "name": "charon1",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 1
     restart: on-failure
     volumes:
@@ -39,7 +39,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 2
     restart: on-failure
     volumes:
@@ -71,7 +71,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 3
     restart: on-failure
     volumes:
@@ -103,7 +103,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 4
     restart: on-failure
     volumes:
@@ -135,7 +135,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         UPSTREAM_VERSION: v0.19.0
-        VALIDATOR_CLIENT_VERSION: v1.13.0
+        VALIDATOR_CLIENT_VERSION: v1.15.1
         CLUSTER_ID: 5
     restart: on-failure
     volumes:


### PR DESCRIPTION
This PR depends on this PR: https://github.com/dappnode/DAppNodeSDK/pull/390

Once it's merged, building arm64 for this package will be possible with this one line change.