### PR TITLE
Add validator extra opts to cluster 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       - DEFAULT_FEE_RECIPIENT=0x0000000000000000000000000000000000000000
       - GRAFFITI=validating_from_DAppNode
       - JAVA_OPTS=-Xmx5g
+      - VALIDATOR_EXTRA_OPTS
       - CUSTOM_BEACON_NODE_URLS
     ports:
       - 3412:3412/tcp


### PR DESCRIPTION
Add `VALIDATOR_EXTRA_OPTS` as an env to cluster 2, the same as the rest