### PR TITLE
Bump lodestar@v1.19.0 and get binary from assets

### DIFF
--- a/charon-validator/Dockerfile.lodestar
+++ b/charon-validator/Dockerfile.lodestar
@@ -7,13 +7,13 @@ ARG VALIDATOR_CLIENT_VERSION
 USER root
 
 RUN apt-get update && apt-get install -y curl && \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs jq zip xz-utils inotify-tools && \
+    apt-get install -y jq zip xz-utils inotify-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 RUN mkdir -p /opt/validator/bin && \
-    curl -L https://github.com/ChainSafe/lodestar/releases/download/${VALIDATOR_CLIENT_VERSION}/lodestar-${VALIDATOR_CLIENT_VERSION}-linux-amd64.tar.gz | tar -xz -C /opt/validator/bin
+    curl -L https://github.com/ChainSafe/lodestar/releases/download/${VALIDATOR_CLIENT_VERSION}/lodestar-${VALIDATOR_CLIENT_VERSION}-linux-amd64.tar.gz | tar -xz -C /opt/validator/bin && \
+    chmod +x /opt/validator/bin/lodestar
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/charon-validator/Dockerfile.lodestar
+++ b/charon-validator/Dockerfile.lodestar
@@ -1,48 +1,27 @@
 ARG CHARON_VERSION
-
-FROM node:20-bullseye-slim as lodestar-build
-
-WORKDIR /usr/app
-
-RUN apt update && apt install -y git g++ make python3 && \
-    ln -s /usr/bin/python3 /usr/bin/python
-
-RUN git clone https://github.com/ChainSafe/lodestar
-
-ARG VALIDATOR_CLIENT_VERSION
-
-RUN cd ./lodestar && \
-    git checkout ${VALIDATOR_CLIENT_VERSION} && \
-    yarn install --non-interactive --frozen-lockfile && \
-    yarn build && \
-    yarn install --non-interactive --frozen-lockfile --production
-
 FROM obolnetwork/charon:${CHARON_VERSION}
+
+ARG CLUSTER_ID
+ARG VALIDATOR_CLIENT_VERSION
 
 USER root
 
-# Install NodeJS to run Lodestar
-RUN apt-get update && \
-    apt-get install -y curl jq zip xz-utils inotify-tools && \
+RUN apt-get update && apt-get install -y curl && \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs jq zip xz-utils inotify-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-RUN curl -SLO https://deb.nodesource.com/nsolid_setup_deb.sh && \
-    chmod 500 nsolid_setup_deb.sh && \
-    ./nsolid_setup_deb.sh 20 && \
-    apt-get install -y nodejs && \
-    rm nsolid_setup_deb.sh
-
-COPY --from=lodestar-build /usr/app/lodestar /opt/validator
+RUN mkdir -p /opt/validator/bin && \
+    curl -L https://github.com/ChainSafe/lodestar/releases/download/${VALIDATOR_CLIENT_VERSION}/lodestar-${VALIDATOR_CLIENT_VERSION}-linux-amd64.tar.gz | tar -xz -C /opt/validator/bin
 
 COPY entrypoint.sh /entrypoint.sh
 
 # To prevent the user from editing the CLUSTER_ID, we set it as an ARG
-ARG CLUSTER_ID
 ENV CLUSTER_ID=${CLUSTER_ID} \
     CHARON_LOG_FORMAT=console \
     NETWORK=mainnet \ 
-    VALIDATOR_SERVICE_BIN=/opt/validator/packages/cli/bin/lodestar \
+    VALIDATOR_SERVICE_BIN=/opt/validator/bin/lodestar \
     VALIDATOR_DATA_DIR=/opt/validator/data \
     VALIDATOR_METRICS_PORT=8008 \
     CHARON_VALIDATOR_API_ADDRESS="0.0.0.0:3600" \

--- a/charon-validator/entrypoint.sh
+++ b/charon-validator/entrypoint.sh
@@ -284,7 +284,6 @@ function run_lodestar() {
             --graffiti="${GRAFFITI}" \
             --suggestedFeeRecipient="${DEFAULT_FEE_RECIPIENT}" \
             --distributed \
-            --useProduceBlockV3=false \
             ${VALIDATOR_EXTRA_OPTS}
     ) &
     VALIDATOR_CLIENT_PID=$!
@@ -306,7 +305,8 @@ function run_teku() {
             --network=${NETWORK} \
             --validators-proposer-default-fee-recipient=${DEFAULT_FEE_RECIPIENT} \
             --validators-graffiti=${GRAFFITI} \
-            --Xblock-v3-enabled=false \
+            --Xblock-v3-enabled=true \
+            --Xobol-dvt-integration-enabled=true \
             ${VALIDATOR_EXTRA_OPTS}
     ) &
     VALIDATOR_CLIENT_PID=$!

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -4,7 +4,7 @@
   "upstream": [
     {
       "repo": "ObolNetwork/charon",
-      "version": "v0.19.2",
+      "version": "v1.0.0-rc4",
       "arg": "CHARON_VERSION"
     },
     {

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -9,7 +9,7 @@
     },
     {
       "repo": "ChainSafe/lodestar",
-      "version": "v1.18.1",
+      "version": "v1.19.0",
       "arg": "VALIDATOR_CLIENT_VERSION"
     }
   ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc4
         VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 1
     restart: on-failure
@@ -39,7 +39,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc4
         VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 2
     restart: on-failure
@@ -73,7 +73,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc4
         VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 3
     restart: on-failure
@@ -107,7 +107,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc4
         VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 4
     restart: on-failure
@@ -141,7 +141,7 @@ services:
       context: charon-validator
       dockerfile: Dockerfile.lodestar
       args:
-        CHARON_VERSION: v0.19.2
+        CHARON_VERSION: v1.0.0-rc4
         VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 5
     restart: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 1
     restart: on-failure
     volumes:
@@ -40,7 +40,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 2
     restart: on-failure
     volumes:
@@ -74,7 +74,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 3
     restart: on-failure
     volumes:
@@ -108,7 +108,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 4
     restart: on-failure
     volumes:
@@ -142,7 +142,7 @@ services:
       dockerfile: Dockerfile.lodestar
       args:
         CHARON_VERSION: v0.19.2
-        VALIDATOR_CLIENT_VERSION: v1.18.1
+        VALIDATOR_CLIENT_VERSION: v1.19.0
         CLUSTER_ID: 5
     restart: on-failure
     volumes:


### PR DESCRIPTION
Get binary from the release assets of https://github.com/ChainSafe/lodestar and bump its version to `v1.19.0`

Includes all changes made in:
https://github.com/dappnode/DAppNodePackage-holesky-obol/pull/59
https://github.com/dappnode/DAppNodePackage-holesky-obol/pull/60
https://github.com/dappnode/DAppNodePackage-holesky-obol/pull/61